### PR TITLE
Remove inactive AI chat icons and enlarge assistant badge

### DIFF
--- a/script.js
+++ b/script.js
@@ -5207,18 +5207,10 @@ getAIAssistantView() {
                     </div>
                 <div class="ai-chat-input-bar">
                     <div class="ai-input-row">
-                        <button type="button" class="ai-input-icon-button" aria-label="Insert suggestion">
-                            <i class="fas fa-plus"></i>
-                        </button>
                         <input type="text" id="ai-chat-input" class="form-input flex-1" placeholder="Ask a follow-up question..." onkeypress="if(event.key === 'Enter') app.submitAIChatMessage()">
-                        <div class="ai-input-actions">
-                            <button type="button" class="ai-input-icon-button" aria-label="Start voice input">
-                                <i class="fas fa-microphone"></i>
-                            </button>
-                            <button type="button" class="ai-send-button" onclick="app.submitAIChatMessage()" aria-label="Send message">
-                                <i class="fas fa-arrow-up"></i>
-                            </button>
-                        </div>
+                        <button type="button" class="ai-send-button" onclick="app.submitAIChatMessage()" aria-label="Send message">
+                            <i class="fas fa-arrow-up"></i>
+                        </button>
                     </div>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -2133,10 +2133,10 @@
 }
 
 .ai-icon-gradient {
-    background: linear-gradient(135deg, #7c3aed 0%, #0ea5e9 100%);
+    background: linear-gradient(135deg, #c084fc 0%, #7c3aed 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
-    font-size: 2.5rem;
+    font-size: 3rem;
 }
 
 .theme-light .ai-header-icon {
@@ -2147,7 +2147,7 @@
 .ai-input-row {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0.5rem;
     background: linear-gradient(135deg, rgba(124, 58, 237, 0.18) 0%, rgba(14, 165, 233, 0.18) 100%);
     border: 1px solid rgba(124, 58, 237, 0.35);
     border-radius: 9999px;


### PR DESCRIPTION
## Summary
- remove the inactive attachment and microphone controls from the AI chat input bar, retaining only the send button
- adjust the assistant header icon styling so the Bubble AI badge appears larger and in its intended purple color

## Testing
- Manual UI verification

------
https://chatgpt.com/codex/tasks/task_b_68d7f595cc2c832fb83cc8ef7b560c7e