### PR TITLE
Add follow-up suggestion buttons to Bubble AI replies

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -97,6 +97,20 @@ app.post('/api/ask-ai', async (req, res) => {
         - Your response MUST be valid HTML. Use semantic elements such as <h2>, <ul>, <li>, <p>, and <strong>.
         - If structured data is best shown in a table, output a clean HTML <table> with the class "ai-data-table" for styling.
 
+        **Follow-up Questions (for business conversations):**
+        - When the latest user message is a business question (not a casual greeting), append a follow-up section after the main answer.
+        - The section must use this exact structure:
+            <div class="ai-followup-section">
+                <h3>Suggested follow-up questions</h3>
+                <div class="ai-followup-bubbles">
+                    <button type="button" class="ai-followup-button" data-action="ask-ai-followup" data-question="QUESTION 1">QUESTION 1</button>
+                    <button type="button" class="ai-followup-button" data-action="ask-ai-followup" data-question="QUESTION 2">QUESTION 2</button>
+                    <button type="button" class="ai-followup-button" data-action="ask-ai-followup" data-question="QUESTION 3">QUESTION 3</button>
+                </div>
+            </div>
+        - Replace QUESTION 1-3 with three concise, relevant follow-up questions tailored to the conversation. Avoid quotation marks inside the data-question value.
+        - Do not include this follow-up section for simple greetings or casual chatter.
+
         **High-Level Business Summary (ignore for simple greetings):**
         ${JSON.stringify(summary, null, 2)}
     `;

--- a/script.js
+++ b/script.js
@@ -660,6 +660,13 @@ nboxNotificationInterval: null,
         'login-manager': () => this.selectUser('manager'),
         'login-worker': () => this.selectUser('worker'),
         'ask-ai': (id) => this.handleAiQuestion(id),
+        'ask-ai-followup': () => {
+            const followupEl = event?.target?.closest('[data-action="ask-ai-followup"][data-question]');
+            const question = followupEl?.getAttribute('data-question');
+            if (question) {
+                this.handleAiQuestion(question.trim());
+            }
+        },
         'share-ai-response': () => {
             NotificationSystem.info('Sharing options coming soon.');
         },

--- a/style.css
+++ b/style.css
@@ -2820,6 +2820,65 @@ div[data-highlight-numbers="true"] .ai-answer-body .negative-amount {
     font-weight: 700;
 }
 
+/* === Suggested Follow-up Questions Styling === */
+.ai-followup-section {
+    margin-top: 1.75rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--border-color);
+}
+
+.ai-followup-section h3 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.ai-followup-bubbles {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+}
+
+.ai-followup-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    background: var(--bg-tertiary);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    color: var(--text-secondary);
+    border-radius: 999px;
+    padding: 0.45rem 0.95rem;
+    font-size: 0.95rem;
+    line-height: 1.2;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 4px 14px rgba(15, 23, 42, 0.18);
+}
+
+.ai-followup-button:hover,
+.ai-followup-button:focus {
+    background: var(--ai-color);
+    color: #0f172a;
+    border-color: transparent;
+    box-shadow: 0 6px 20px rgba(79, 70, 229, 0.35);
+}
+
+.ai-followup-button i {
+    font-size: 0.85rem;
+}
+
+.ai-answer-body[dir="rtl"] .ai-followup-bubbles {
+    justify-content: flex-end;
+}
+
+.ai-answer-body[dir="rtl"] .ai-followup-button {
+    direction: rtl;
+}
+
 /* === NEW: AI Icon Shine Animation === */
 @keyframes icon-shine-sweep {
     from { background-position: 200% center; }


### PR DESCRIPTION
## Summary
- instruct Bubble AI via the server prompt to append a follow-up question section with three suggestion buttons on business answers
- allow the web client to submit AI follow-up questions directly from the rendered buttons
- style the follow-up section so the suggestions appear as interactive bubbles that support RTL layouts

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68d84044a06c832f80efb61bc8c2c6f9