### PR TITLE
Reorder AI follow-up suggestions below action icons

### DIFF
--- a/script.js
+++ b/script.js
@@ -5336,13 +5336,33 @@ renderAIChatHistory() {
         return '';
     }).join('');
 
+    this.repositionAIFollowups();
     this.scrollAIChatToBottom();
-    requestAnimationFrame(() => this.applyAIResponseAnimation());
+    requestAnimationFrame(() => {
+        this.applyAIResponseAnimation();
+        this.repositionAIFollowups();
+    });
 },
 
 // REPLACE THE OLD FUNCTION WITH THIS WORKING JAVASCRIPT VERSION
 
 // REPLACE THE OLD handleAiTtsClick FUNCTION WITH THIS ONE
+repositionAIFollowups() {
+    const wrappers = document.querySelectorAll('.ai-answer-wrapper');
+    wrappers.forEach(wrapper => {
+        const body = wrapper.querySelector('.ai-answer-body');
+        const footer = wrapper.querySelector('.ai-answer-footer');
+        if (!body || !footer) {
+            return;
+        }
+
+        const followupSections = body.querySelectorAll('.ai-followup-section');
+        followupSections.forEach(section => {
+            footer.insertAdjacentElement('afterend', section);
+        });
+    });
+},
+
 async handleAiTtsClick(index) {
     const headerEl = document.querySelector(`.ai-answer-header[data-message-index="${index}"]`);
     if (headerEl) {

--- a/style.css
+++ b/style.css
@@ -2822,9 +2822,13 @@ div[data-highlight-numbers="true"] .ai-answer-body .negative-amount {
 
 /* === Suggested Follow-up Questions Styling === */
 .ai-followup-section {
-    margin-top: 1.75rem;
-    padding-top: 1.25rem;
+    margin-top: 1.25rem;
+    padding-top: 1rem;
     border-top: 1px solid var(--border-color);
+}
+
+.ai-answer-wrapper > .ai-followup-section {
+    width: 100%;
 }
 
 .ai-followup-section h3 {


### PR DESCRIPTION
## Summary
- add a DOM post-processing helper that moves AI follow-up suggestions beneath the action toolbar
- adjust the AI chat rendering cycle to invoke the new helper whenever the chat view refreshes
- tweak follow-up spacing styles for the relocated section so it still aligns with the chat layout

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68d84a4f5210832fadbad0d1e503b513