### PR TITLE
Restyle sales performance chart

### DIFF
--- a/style.css
+++ b/style.css
@@ -1311,6 +1311,34 @@
             width: 100%;
         }
 
+        .sales-performance-chart {
+            padding: 1.25rem;
+            border-radius: 1.25rem;
+            background:
+                radial-gradient(140% 140% at 100% 0%, rgba(250, 204, 21, 0.2) 0%, rgba(8, 47, 73, 0) 60%),
+                linear-gradient(180deg, rgba(15, 23, 42, 0.7) 0%, rgba(15, 23, 42, 0.35) 100%);
+            border: 1px solid rgba(250, 204, 21, 0.18);
+            box-shadow: inset 0 0 30px rgba(8, 11, 19, 0.55);
+            overflow: hidden;
+        }
+
+        .sales-performance-chart::after {
+            content: "";
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 40%;
+            background: linear-gradient(180deg, rgba(250, 204, 21, 0.22) 0%, rgba(250, 204, 21, 0) 100%);
+            opacity: 0.35;
+            pointer-events: none;
+        }
+
+        .sales-performance-chart canvas {
+            position: relative;
+            z-index: 1;
+        }
+
         /* === REPLACEMENT: Enhanced Toggle Switch Animation === */
 
 


### PR DESCRIPTION
## Summary
- replace the Sales Performance chart rendering with a custom builder that applies a golden gradient area style and pulsing point animation
- ensure both dashboard initialization and live updates reuse the new chart styling without affecting other charts
- add tailored styling around the chart container to mirror the provided visual design

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68d916cdd000832f8efcc0809df6dfbb