### PR TITLE
Stabilize mobile navigation performance

### DIFF
--- a/script.js
+++ b/script.js
@@ -68,40 +68,35 @@ const salesGlowPlugin = {
         if (!datasetMeta || datasetMeta.hidden) return;
 
         const ctx = chart.ctx;
-        const now = performance.now();
+        const baseRadius = pluginOptions.baseRadius || 5;
+        const glowSpread = pluginOptions.glowRadius || 4;
 
-        datasetMeta.data.forEach((point, index) => {
+        datasetMeta.data.forEach((point) => {
             const position = point.tooltipPosition();
-            const pulse = (Math.sin((now / (pluginOptions.speed || 1200)) + index) + 1) / 2;
-            const radius = (pluginOptions.baseRadius || 4) + pulse * (pluginOptions.pulseRadius || 3);
+            const radius = baseRadius;
+            const outerRadius = radius + glowSpread;
 
             ctx.save();
             ctx.beginPath();
-            ctx.arc(position.x, position.y, radius, 0, Math.PI * 2);
+            ctx.arc(position.x, position.y, outerRadius, 0, Math.PI * 2);
 
-            const glowGradient = ctx.createRadialGradient(position.x, position.y, radius * 0.2, position.x, position.y, radius);
+            const glowGradient = ctx.createRadialGradient(
+                position.x,
+                position.y,
+                radius * 0.4,
+                position.x,
+                position.y,
+                outerRadius
+            );
             glowGradient.addColorStop(0, pluginOptions.pointColor || '#facc15');
             glowGradient.addColorStop(1, 'rgba(250, 204, 21, 0)');
 
             ctx.fillStyle = glowGradient;
             ctx.shadowColor = pluginOptions.glowColor || 'rgba(250, 204, 21, 0.45)';
-            ctx.shadowBlur = 12 + pulse * 10;
+            ctx.shadowBlur = pluginOptions.shadowBlur ?? 16;
             ctx.fill();
             ctx.restore();
         });
-
-        if (!chart.$salesGlowFrame) {
-            chart.$salesGlowFrame = requestAnimationFrame(() => {
-                chart.$salesGlowFrame = null;
-                chart.draw();
-            });
-        }
-    },
-    beforeDestroy(chart) {
-        if (chart.$salesGlowFrame) {
-            cancelAnimationFrame(chart.$salesGlowFrame);
-            chart.$salesGlowFrame = null;
-        }
     }
 };
 
@@ -205,8 +200,8 @@ function createSalesPerformanceChart(ctx, labels, values, datasetLabel, currency
                     glowColor: 'rgba(250, 204, 21, 0.45)',
                     pointColor: '#facc15',
                     baseRadius: 4,
-                    pulseRadius: 3,
-                    speed: 1200
+                    glowRadius: 3,
+                    shadowBlur: 18
                 }
             },
             animations: {
@@ -722,6 +717,7 @@ nboxNotificationInterval: null,
     const savedTheme = DataStorage.load('OwlioTheme') || 'dark-theme'; // Default to dark
     this.setTheme(savedTheme);
     this.render();
+    this.setupViewportObservers();
     this.bindEvents();
     this.updateAIInsights();
     this.updateBotAnalysis();
@@ -758,7 +754,7 @@ nboxNotificationInterval: null,
                 this.state.mobileMenuOpen = !this.state.mobileMenuOpen;
                 const sidebar = document.getElementById('mobile-sidebar');
                 const overlay = document.getElementById('sidebar-overlay');
-                
+
                 if (this.state.mobileMenuOpen) {
                     sidebar?.classList.add('open');
                     overlay?.classList.add('open');
@@ -766,15 +762,53 @@ nboxNotificationInterval: null,
                     sidebar?.classList.remove('open');
                     overlay?.classList.remove('open');
                 }
+
+                if (document?.body) {
+                    document.body.classList.toggle('no-scroll', this.state.mobileMenuOpen);
+                }
             },
 
             closeMobileSidebar() {
                 this.state.mobileMenuOpen = false;
                 const sidebar = document.getElementById('mobile-sidebar');
                 const overlay = document.getElementById('sidebar-overlay');
-                
+
                 sidebar?.classList.remove('open');
                 overlay?.classList.remove('open');
+
+                if (document?.body) {
+                    document.body.classList.remove('no-scroll');
+                }
+            },
+
+            setupViewportObservers() {
+                if (!this.boundViewportHandler) {
+                    this.boundViewportHandler = () => this.handleViewportChange();
+                }
+
+                this.handleViewportChange();
+
+                if (!this.viewportObserversAttached) {
+                    window.addEventListener('resize', this.boundViewportHandler, { passive: true });
+                    window.addEventListener('orientationchange', this.boundViewportHandler);
+                    this.viewportObserversAttached = true;
+                }
+            },
+
+            handleViewportChange() {
+                this.applyPerformanceMode();
+
+                if (window.innerWidth >= 1024 && this.state.mobileMenuOpen) {
+                    this.closeMobileSidebar();
+                }
+            },
+
+            applyPerformanceMode() {
+                const body = document?.body;
+                if (!body || typeof window === 'undefined' || !window.matchMedia) return;
+
+                const reduceEffects = window.matchMedia('(max-width: 768px)').matches;
+                body.classList.toggle('performance-mode', reduceEffects);
             },
 
             updateAIInsights() {

--- a/style.css
+++ b/style.css
@@ -415,6 +415,72 @@
             opacity: 0;
             visibility: hidden;
             transition: all 0.3s ease;
+            pointer-events: none;
+        }
+
+        body.no-scroll {
+            overflow: hidden;
+        }
+
+        body.performance-mode {
+            background-color: var(--bg-primary);
+        }
+
+        body.performance-mode .navbar,
+        body.performance-mode .mobile-sidebar,
+        body.performance-mode .desktop-sidebar,
+        body.performance-mode .glass-panel,
+        body.performance-mode .dashboard-hero,
+        body.performance-mode .stat-card,
+        body.performance-mode .metric-card,
+        body.performance-mode .quick-action-card,
+        body.performance-mode .ai-card,
+        body.performance-mode .ai-response-card,
+        body.performance-mode .timeline-card,
+        body.performance-mode .kanban-column,
+        body.performance-mode .kanban-card,
+        body.performance-mode .modal-content,
+        body.performance-mode .notification,
+        body.performance-mode .summary-card,
+        body.performance-mode .report-card,
+        body.performance-mode .quick-sale-step-container,
+        body.performance-mode .quick-sale-review,
+        body.performance-mode .quick-sale-actions,
+        body.performance-mode .branch-card,
+        body.performance-mode .inbox-thread,
+        body.performance-mode .ai-insight-card,
+        body.performance-mode .sales-performance-card,
+        body.performance-mode .finance-card,
+        body.performance-mode .kanban-board,
+        body.performance-mode .task-card,
+        body.performance-mode .card,
+        body.performance-mode .info-card,
+        body.performance-mode .performance-card,
+        body.performance-mode .report-widget {
+            backdrop-filter: none !important;
+            -webkit-backdrop-filter: none !important;
+            box-shadow: none !important;
+        }
+
+        body.performance-mode .navbar,
+        body.performance-mode .mobile-sidebar,
+        body.performance-mode .desktop-sidebar,
+        body.performance-mode .glass-panel,
+        body.performance-mode .dashboard-hero,
+        body.performance-mode .stat-card,
+        body.performance-mode .quick-action-card,
+        body.performance-mode .ai-card,
+        body.performance-mode .ai-response-card,
+        body.performance-mode .modal-content,
+        body.performance-mode .notification,
+        body.performance-mode .quick-sale-step-container,
+        body.performance-mode .quick-sale-review,
+        body.performance-mode .quick-sale-actions,
+        body.performance-mode .task-card,
+        body.performance-mode .summary-card,
+        body.performance-mode .report-card,
+        body.performance-mode .report-widget {
+            background: var(--bg-secondary, rgba(11, 18, 32, 0.92)) !important;
         }
  
         /* === NEW CSS FOR QUICK SALE === */
@@ -712,6 +778,7 @@
         .sidebar-overlay.open {
             opacity: 1;
             visibility: visible;
+            pointer-events: auto;
         }
 
         /* Desktop Sidebar */


### PR DESCRIPTION
## Summary
- replace the requestAnimationFrame-based glow pulse with a static radial glow rendering
- retune the salesGlow plugin options to match the new static glow styling
- lock body scrolling behind the mobile sidebar and enable a reduced-effects mode on small screens for smoother navigation

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68d92825c6b0832fa4e185c63f1e96a5